### PR TITLE
Stop caching 404s.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
     image: quay.io/continuouspipe/drupal8-varnish4:stable
     links:
       - web
+    environment:
+      DRUPAL_CACHE_ERRORS: "false"
     expose:
       - 80
 


### PR DESCRIPTION
Varnish was caching 404s and other errors. Imports https://github.com/continuouspipe/dockerfiles/pull/236